### PR TITLE
fix: Nomenclature of S3 Bucket while creation

### DIFF
--- a/packages/serverless-aws-s3/utils.js
+++ b/packages/serverless-aws-s3/utils.js
@@ -39,6 +39,10 @@ const bucketCreation = async (s3, Bucket) => {
 const ensureBucket = async (s3, name, debug) => {
     try {
         debug(`Checking if bucket ${name} exists.`);
+        debug(`Checking bucket ${name} for uppercase check.`);
+        if(name[0]>=65 && name[0]<=90){
+            throw Error(`Bucket name must not contain uppercase characters`);
+        }
         await s3.headBucket({ Bucket: name }).promise();
     } catch (e) {
         if (e.code === "NotFound") {


### PR DESCRIPTION
fix: Nomenclature of S3 Bucket while creation

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->
Checking the beginning of the bucket name is uppercase or not, if yes then should throw error.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if relevant):
NA